### PR TITLE
docs: sync release readiness documentation to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,37 +10,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Core Features
-- **Smart Case Preservation**: Automatically detects and preserves case styles (camelCase, PascalCase, kebab-case, snake_case, UPPERCASE, lowercase)
+
+- **Smart Case Preservation**: Automatically detects and preserves case styles (camelCase, PascalCase, kebab-case, snake_case, UPPERCASE, compact uppercase, lowercase)
 - **Comprehensive Renaming**: Renames file contents, file names, directory names, and package references
 - **Dry Run Mode**: Preview changes without making any modifications
 - **Interactive Confirmation**: User confirmation prompts with detailed change analysis
 - **Ignore Patterns**: Built-in and custom ignore patterns for safe operation
 
 #### CLI Interface
+
 - **Command Line Interface**: Full-featured CLI with comprehensive options
 - **Interactive Mode**: Step-by-step guided interface for ease of use
 - **Verbose Output**: Detailed logging and progress reporting
 - **Help and Documentation**: Built-in help system with examples
 
 #### Safety Features
+
 - **Backup Detection**: Prevents accidental overwrites of important directories
 - **Binary File Detection**: Automatically skips binary files to prevent corruption
 - **Error Handling**: Graceful error handling with meaningful error messages
 - **Git Integration**: Optional git configuration updates
 
 #### TypeScript & Modern Tooling
+
 - **Full TypeScript Support**: Written in TypeScript with complete type definitions
 - **ES Modules**: Modern ES module architecture
 - **Dual Package Support**: Supports both CommonJS and ES modules
 - **Tree-shaking Ready**: Modular architecture for optimal bundle sizes
 
 #### Testing & Quality
-- Comprehensive test suite with 98% coverage
+
+- Comprehensive test suite with 98%+ source coverage
 - ESLint and Prettier configuration
 - Full TypeScript type checking
 - GitHub Actions CI/CD pipeline
 
 #### Developer Experience
+
 - Programmatic API for library usage
 - Comprehensive documentation
 - npm best practices
@@ -49,15 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Implementation Details
 
 #### Supported Case Styles
+
 - camelCase
 - PascalCase
 - kebab-case
 - snake_case
 - UPPERCASE
+- compact uppercase
 - lowercase
 - Package scope (@namespace)
 
 #### Built-in Ignore Patterns
+
 - `node_modules/**`
 - `.git/**`
 - `dist/**`
@@ -68,17 +77,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.DS_Store` (OS files)
 
 #### Performance
+
 - Fast file scanning with glob patterns
 - Parallel processing where possible
 - Memory-efficient for large codebases
 - Estimated duration calculation
 
 ### Dependencies
+
 - commander - CLI framework
 - glob - File pattern matching
 - inquirer - Interactive prompts
 
 ### Development Dependencies
+
 - typescript - TypeScript compiler
 - tsup - Fast TypeScript bundler
 - vitest - Unit testing framework
@@ -88,12 +100,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - _Nothing yet_
 
 ### Changed
+
 - _Nothing yet_
 
 ### Fixed
+
 - _Nothing yet_
 
 ---
@@ -103,8 +118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This project follows [Semantic Versioning](https://semver.org/) and [Keep a Changelog](https://keepachangelog.com/) format.
 
 ### Commit Message Format
+
 - `feat:` - New features (minor version bump)
-- `fix:` - Bug fixes (patch version bump) 
+- `fix:` - Bug fixes (patch version bump)
 - `BREAKING CHANGE:` - Breaking changes (major version bump)
 - `docs:` - Documentation updates
 - `test:` - Test updates

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![npm version](https://badge.fury.io/js/refacto.svg)](https://www.npmjs.com/package/refacto)
 [![CI](https://github.com/Mule-ME/refacto/actions/workflows/ci.yml/badge.svg)](https://github.com/Mule-ME/refacto/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen.svg)](https://github.com/Mule-ME/refacto)
-[![Tests](https://img.shields.io/badge/tests-79%20passing-brightgreen.svg)](https://github.com/Mule-ME/refacto)
+[![Tests](https://img.shields.io/badge/tests-111%20passing-brightgreen.svg)](https://github.com/Mule-ME/refacto)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Enterprise-grade project renaming tool with 98% test coverage, framework agnostic design, and smart case preservation**
+> **Enterprise-grade project renaming tool with 98%+ source test coverage, framework agnostic design, and smart case preservation**
 
 ```bash
 # One command to rename your entire project across ALL languages & frameworks
@@ -16,27 +16,30 @@ refacto --from "OldProject" --to "AwesomeProject"
 ✓ Renames in JavaScript, Python, Java, Go, Ruby, PHP, Rust, and more...
 ✓ Updates configs, Docker files, CI/CD, documentation...
 ✓ Preserves your code style (camelCase, snake_case, kebab-case, etc.)
-✓ Safe with dry-run mode and 98% test coverage
+✓ Safe with dry-run mode and 98%+ source test coverage
 ```
 
-A powerful, safe, and intelligent tool for renaming projects across your entire codebase. Works with **ANY programming language** and **ANY framework**. Battle-tested with 79 comprehensive tests achieving 98% code coverage.
+A powerful, safe, and intelligent tool for renaming projects across your entire codebase. Works with **ANY programming language** and **ANY framework**. Battle-tested with 111 comprehensive tests achieving 98%+ source code coverage.
 
 ## 🏆 Why Choose refacto?
 
 ### 🌍 **Language & Framework Agnostic**
+
 - **Works with ANY language**: JavaScript, TypeScript, Python, Java, Go, Rust, C++, Ruby, PHP, and more
 - **Works with ANY framework**: React, Vue, Angular, Django, Rails, Spring, Express, and more
 - **Works with ANY file type**: Source code, configs, docs, CI/CD, Docker, K8s manifests
 - **Cross-platform**: Windows, macOS, Linux
 
 ### 🛡️ **Enterprise-Grade Quality**
-- **98% Code Coverage**: 79 comprehensive tests covering all edge cases
+
+- **98%+ Source Code Coverage**: 111 comprehensive tests covering all edge cases
 - **100% TypeScript**: Full type safety and IntelliSense support
 - **Production Ready**: Battle-tested on real projects
 - **Minimal Dependencies**: Only 3 runtime dependencies for maximum security
 
 ### ⚡ **Smart & Safe**
-- **Smart Case Detection**: Preserves your code style across 7 different case formats
+
+- **Smart Case Detection**: Preserves your code style across 8 different case formats
 - **Dry-Run Mode**: Preview all changes before committing
 - **Binary Safe**: Automatically skips binary files, images, and compiled code
 - **Git Aware**: Updates git remote URLs automatically
@@ -64,34 +67,36 @@ A powerful, safe, and intelligent tool for renaming projects across your entire 
   - Detailed change analysis
   - Skips binary files and common build directories
 
-
 ## 🌐 Works With Every Language
 
 The tool intelligently renames across **all programming languages** in your project:
 
 ### JavaScript/TypeScript
+
 ```javascript
 // Before
 export class DataProcessor { ... }
 const dataProcessorConfig = { ... };
 
-// After  
+// After
 export class DataAnalyzer { ... }
 const dataAnalyzerConfig = { ... };
 ```
 
 ### Python
+
 ```python
 # Before
 from analytics_sdk import AnalyticsAPI
 ANALYTICS_KEY = os.getenv('ANALYTICS_KEY')
 
-# After  
+# After
 from metrics_sdk import MetricsAPI
 METRICS_KEY = os.getenv('METRICS_KEY')
 ```
 
 ### Java/Kotlin
+
 ```java
 // Before
 public class PaymentService extends PaymentBase {
@@ -105,6 +110,7 @@ public class BillingService extends BillingBase {
 ```
 
 ### Go
+
 ```go
 // Before
 package userauth
@@ -116,19 +122,21 @@ type AuthenticationConfig struct { ... }
 ```
 
 ### React Native
+
 ```javascript
-// Before  
+// Before
 export default class TodoApp extends Component { ... }
 // ios/TodoApp.xcodeproj
 // android/app/src/main/java/com/todoapp/
 
 // After
 export default class TaskManager extends Component { ... }
-// ios/TaskManager.xcodeproj  
+// ios/TaskManager.xcodeproj
 // android/app/src/main/java/com/taskmanager/
 ```
 
 ### And More!
+
 Works with Ruby, PHP, Rust, C/C++, Swift, Dart, Shell scripts, Docker files, YAML configs, and **any text-based file**!
 
 ## 🚀 Quick Start
@@ -136,6 +144,8 @@ Works with Ruby, PHP, Rust, C/C++, Swift, Dart, Shell scripts, Docker files, YAM
 > **Not a JavaScript developer?** See our [Installation Guide](docs/INSTALLATION.md) for Java, Python, Go, Ruby, PHP, C++ developers!
 
 ### Installation
+
+Requires Node.js 18 or newer and npm 9 or newer.
 
 ```bash
 # Global installation (recommended)
@@ -212,7 +222,7 @@ const renamer = new ProjectRenamer({
   from: 'oldName',
   to: 'newName',
   dryRun: true,
-  verbose: false
+  verbose: false,
 });
 
 // Analyze impact
@@ -232,13 +242,13 @@ const changes = renamer.getChanges();
 
 ```typescript
 interface RenameOptions {
-  from: string;           // Source name to replace
-  to: string;             // Target name to replace with
-  dryRun?: boolean;       // Preview mode (default: false)
-  verbose?: boolean;      // Detailed logging (default: false)
-  skipGit?: boolean;      // Skip git config updates (default: false)
-  ignore?: string[];      // Custom ignore patterns
-  force?: boolean;        // Skip confirmations (default: false)
+  from: string; // Source name to replace
+  to: string; // Target name to replace with
+  dryRun?: boolean; // Preview mode (default: false)
+  verbose?: boolean; // Detailed logging (default: false)
+  skipGit?: boolean; // Skip git config updates (default: false)
+  ignore?: string[]; // Custom ignore patterns
+  force?: boolean; // Skip confirmations (default: false)
 }
 ```
 
@@ -251,7 +261,7 @@ interface RenameOptions {
 
 ## How It Works
 
-1. **Analysis Phase**: 
+1. **Analysis Phase**:
    - Scans the entire project to find all occurrences
    - Counts files, directories, and text replacements
    - Shows preview of changes to be made
@@ -288,12 +298,14 @@ The tool is designed to be safe:
 ## 📊 Quality & Testing
 
 ### Test Coverage
-- 98% overall coverage
-- 79 comprehensive tests
+
+- 98%+ source coverage
+- 111 comprehensive tests
 - Full core logic coverage
 - Cross-platform CI/CD
 
 ### Code Quality
+
 - 100% TypeScript with strict mode
 - ESLint + Prettier enforced
 - Automated dependency updates
@@ -302,7 +314,9 @@ The tool is designed to be safe:
 ## Troubleshooting
 
 ### Case Sensitivity
+
 The tool is case-sensitive. Make sure to provide the exact current name:
+
 ```bash
 # Wrong
 --from "myproject"  # If actual name is "MyProject"
@@ -312,7 +326,9 @@ The tool is case-sensitive. Make sure to provide the exact current name:
 ```
 
 ### Permission Errors
+
 If you encounter permission errors:
+
 ```bash
 # Use with sudo if needed (not recommended)
 sudo refacto --from "OldName" --to "NewName"
@@ -323,18 +339,21 @@ export PATH=~/.npm-global/bin:$PATH
 ```
 
 ### Large Projects
+
 For very large projects (10,000+ files):
+
 ```bash
 # Use verbose mode to see progress
 refacto --from "OldName" --to "NewName" --verbose
 ```
-
 
 ## Contributing
 
 We welcome contributions! This project follows enterprise-grade standards:
 
 ### Development Requirements
+
+- Node.js 20+ for local test tooling; the publish workflow uses Node.js 22+
 - 100% test coverage for new features
 - TypeScript with strict mode
 - ESLint compliance (no warnings)
@@ -342,6 +361,7 @@ We welcome contributions! This project follows enterprise-grade standards:
 - Cross-platform compatibility
 
 ### How to Contribute
+
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Write tests FIRST (TDD approach)
@@ -352,6 +372,7 @@ We welcome contributions! This project follows enterprise-grade standards:
 8. Open a Pull Request
 
 ### Code Standards
+
 ```bash
 # Before submitting PR
 npm run lint        # Must pass with no errors

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A powerful, safe, and intelligent tool for renaming projects across your entire 
 - **Smart Case Detection**: Preserves your code style across 8 different case formats
 - **Dry-Run Mode**: Preview all changes before committing
 - **Binary Safe**: Automatically skips binary files, images, and compiled code
+- **Collision Safe**: Refuses file and directory renames that would overwrite existing paths
 - **Git Aware**: Updates git remote URLs automatically
 
 ## Features
@@ -58,6 +59,7 @@ A powerful, safe, and intelligent tool for renaming projects across your entire 
   - File contents (code, markdown, json, etc.)
   - File names
   - Directory names
+  - Dotfiles and hidden config files
   - Package names
   - Git repository references
 
@@ -65,6 +67,7 @@ A powerful, safe, and intelligent tool for renaming projects across your entire 
   - Dry-run mode to preview changes
   - Confirmation prompt before actual changes
   - Detailed change analysis
+  - Collision checks before file and directory renames
   - Skips binary files and common build directories
 
 ## 🌐 Works With Every Language
@@ -191,11 +194,13 @@ refacto --from "Test" --to "Demo" --force
 
 ### Options
 
-- `--from <name>` - Current project name (required)
-- `--to <name>` - New project name (required)
-- `--dry-run` - Show what would be changed without making changes
+- `--from, -f <name>` - Current project name (required unless using `--interactive`)
+- `--to, -t <name>` - New project name (required unless using `--interactive`)
+- `--dry-run, -d` - Show what would be changed without making changes
 - `--verbose, -v` - Show detailed output
+- `--interactive, -i` - Prompt for rename options interactively
 - `--skip-git` - Skip git repository updates
+- `--force` - Skip confirmation prompts
 - `--help, -h` - Show help message
 
 ### 📋 Examples
@@ -234,6 +239,12 @@ await renamer.rename();
 
 // Get list of changes made
 const changes = renamer.getChanges();
+```
+
+CommonJS is supported too:
+
+```javascript
+const { ProjectRenamer } = require('refacto');
 ```
 
 ### API Reference

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,12 +20,14 @@ Security vulnerabilities should **never** be reported through public GitHub issu
 ### 2. Report Privately
 
 Please report vulnerabilities through one of these channels:
+
 - **Preferred**: Create a [private security advisory](https://github.com/Mule-ME/refacto/security/advisories/new)
 - **Alternative**: Contact the maintainer directly via GitHub
 
 ### 3. What to Include in Your Report
 
 Please provide:
+
 - **Type of issue** (e.g., buffer overflow, command injection, cross-site scripting, etc.)
 - **Full paths** of source file(s) related to the manifestation of the issue
 - **Location** of the affected source code (tag/branch/commit or direct URL)
@@ -38,7 +40,7 @@ Please provide:
 
 - **Initial Response**: Within 48 hours
 - **Status Update**: Within 5 business days
-- **Resolution Target**: 
+- **Resolution Target**:
   - Critical: 1-3 days
   - High: 7 days
   - Medium: 14 days
@@ -65,12 +67,14 @@ When using refacto:
 ## Security Measures We Take
 
 ### Code Security
+
 - Regular dependency updates via Dependabot
 - Automated security scanning in CI/CD
 - Code review for all changes
 - Type safety with TypeScript
 
 ### Runtime Security
+
 - Input validation and sanitization
 - Safe file system operations
 - No execution of external commands without validation
@@ -79,14 +83,16 @@ When using refacto:
 ## Dependencies
 
 We actively monitor and update dependencies:
+
 - **Automated updates**: Dependabot PRs weekly
 - **Manual audits**: Quarterly security reviews
-- **CI checks**: `npm audit` on every build
+- **CI checks**: dependency audit (`npm audit`) on every build
 - **Zero tolerance**: Critical vulnerabilities fixed immediately
 
 ## Acknowledgments
 
 We appreciate security researchers who help keep refacto safe. Security contributors will be recognized in:
+
 - Release notes
 - GitHub Security Advisories
 - This document (Hall of Fame - coming soon)

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,17 +33,17 @@ refacto --from "old-name" --to "new-name"
 
 ### Options
 
-| Option | Alias | Description | Default |
-|--------|-------|-------------|---------|
-| `--from` | `-f` | Current project name (required) | - |
-| `--to` | `-t` | New project name (required) | - |
-| `--dry-run` | `-d` | Preview changes without applying | false |
-| `--verbose` | `-v` | Show detailed output | false |
-| `--skip-git` | | Skip git remote URL updates | false |
-| `--ignore` | `-i` | Additional ignore patterns | [] |
-| `--force` | | Skip confirmation prompt | false |
-| `--help` | `-h` | Show help | - |
-| `--version` | | Show version | - |
+| Option       | Alias | Description                      | Default |
+| ------------ | ----- | -------------------------------- | ------- |
+| `--from`     | `-f`  | Current project name (required)  | -       |
+| `--to`       | `-t`  | New project name (required)      | -       |
+| `--dry-run`  | `-d`  | Preview changes without applying | false   |
+| `--verbose`  | `-v`  | Show detailed output             | false   |
+| `--skip-git` |       | Skip git remote URL updates      | false   |
+| `--ignore`   | `-i`  | Additional ignore patterns       | []      |
+| `--force`    |       | Skip confirmation prompt         | false   |
+| `--help`     | `-h`  | Show help                        | -       |
+| `--version`  |       | Show version                     | -       |
 
 ### Examples
 
@@ -72,7 +72,7 @@ const renamer = new ProjectRenamer({
   from: 'old-name',
   to: 'new-name',
   dryRun: false,
-  verbose: true
+  verbose: true,
 });
 
 // Analyze changes
@@ -112,6 +112,7 @@ Analyzes the project and returns information about what would be changed.
 **Returns:** `RenameAnalysis` object with change statistics
 
 **Example:**
+
 ```typescript
 const analysis = await renamer.analyze();
 console.log(`Will change ${analysis.contentChanges} files`);
@@ -126,6 +127,7 @@ async rename(): Promise<void>
 Performs the actual rename operation. Will show progress if verbose is enabled.
 
 **Example:**
+
 ```typescript
 await renamer.rename();
 ```
@@ -141,6 +143,7 @@ Returns an array of all changes made during the rename operation.
 **Returns:** Array of `RenameChange` objects
 
 **Example:**
+
 ```typescript
 const changes = renamer.getChanges();
 changes.forEach(change => {
@@ -157,11 +160,13 @@ smartReplace(text: string): { result: string; replacements: number }
 Performs smart case-preserving replacement on the given text.
 
 **Parameters:**
+
 - `text`: The text to process
 
 **Returns:** Object with replaced text and replacement count
 
 **Example:**
+
 ```typescript
 const { result, replacements } = renamer.smartReplace('MyApp is great');
 // result: 'NewApp is great', replacements: 1
@@ -182,6 +187,7 @@ generateVariations(text: string): Map<string, CaseStyle>
 Generates all case variations of the given text.
 
 **Example:**
+
 ```typescript
 const converter = new CaseConverter();
 const variations = converter.generateVariations('MyProject');
@@ -191,12 +197,13 @@ const variations = converter.generateVariations('MyProject');
 ##### detectCaseStyle()
 
 ```typescript
-detectCaseStyle(text: string): CaseStyle | null
+detectCaseStyle(text: string): CaseStyle
 ```
 
 Detects the case style of the given text.
 
 **Example:**
+
 ```typescript
 const style = converter.detectCaseStyle('my-project');
 // Returns 'kebab-case'
@@ -256,13 +263,13 @@ constructor(verbose: boolean = false)
 
 ```typescript
 interface RenameOptions {
-  from: string;           // Current project name
-  to: string;             // New project name
-  dryRun?: boolean;       // Preview only (default: false)
-  verbose?: boolean;      // Detailed output (default: false)
-  skipGit?: boolean;      // Skip git updates (default: false)
-  ignore?: string[];      // Additional ignore patterns
-  force?: boolean;        // Skip confirmation (default: false)
+  from: string; // Current project name
+  to: string; // New project name
+  dryRun?: boolean; // Preview only (default: false)
+  verbose?: boolean; // Detailed output (default: false)
+  skipGit?: boolean; // Skip git updates (default: false)
+  ignore?: string[]; // Additional ignore patterns
+  force?: boolean; // Skip confirmation (default: false)
 }
 ```
 
@@ -270,11 +277,11 @@ interface RenameOptions {
 
 ```typescript
 interface RenameAnalysis {
-  contentChanges: number;      // Files with content changes
-  fileRenames: number;         // Files to rename
-  dirRenames: number;          // Directories to rename
-  totalReplacements: number;   // Total text replacements
-  estimatedDuration: number;   // Estimated seconds
+  contentChanges: number; // Files with content changes
+  fileRenames: number; // Files to rename
+  dirRenames: number; // Directories to rename
+  totalReplacements: number; // Total text replacements
+  estimatedDuration: number; // Estimated seconds
 }
 ```
 
@@ -284,20 +291,21 @@ interface RenameAnalysis {
 interface RenameChange {
   type: 'content' | 'file' | 'directory';
   oldPath: string;
-  newPath?: string;      // For file/directory renames
-  changes?: number;      // For content changes
+  newPath?: string; // For file/directory renames
+  changes?: number; // For content changes
 }
 ```
 
 ### CaseStyle
 
 ```typescript
-type CaseStyle = 
+type CaseStyle =
   | 'camelCase'
   | 'PascalCase'
   | 'kebab-case'
   | 'snake_case'
   | 'UPPERCASE'
+  | 'UPPERCASE_COMPACT'
   | 'lowercase';
 ```
 
@@ -305,9 +313,9 @@ type CaseStyle =
 
 ```typescript
 interface ScanOptions {
-  ignore?: string[];         // Ignore patterns
-  includeHidden?: boolean;   // Include hidden files
-  maxDepth?: number;         // Maximum depth
+  ignore?: string[]; // Ignore patterns
+  includeHidden?: boolean; // Include hidden files
+  maxDepth?: number; // Maximum depth
 }
 ```
 
@@ -335,9 +343,9 @@ import { ProjectRenamer } from 'refacto';
 try {
   const renamer = new ProjectRenamer({
     from: 'old-name',
-    to: 'new-name'
+    to: 'new-name',
   });
-  
+
   await renamer.rename();
 } catch (error) {
   console.error('Rename failed:', error.message);
@@ -350,11 +358,7 @@ try {
 const renamer = new ProjectRenamer({
   from: 'old-name',
   to: 'new-name',
-  ignore: [
-    'vendor/**',
-    'legacy/**',
-    '*.backup'
-  ]
+  ignore: ['vendor/**', 'legacy/**', '*.backup'],
 });
 ```
 
@@ -367,37 +371,37 @@ const { ProjectRenamer } = require('refacto');
 module.exports = {
   plugins: [
     {
-      apply: (compiler) => {
+      apply: compiler => {
         compiler.hooks.beforeCompile.tapPromise('RenamePlugin', async () => {
           if (process.env.RENAME_FROM && process.env.RENAME_TO) {
             const renamer = new ProjectRenamer({
               from: process.env.RENAME_FROM,
-              to: process.env.RENAME_TO
+              to: process.env.RENAME_TO,
             });
             await renamer.rename();
           }
         });
-      }
-    }
-  ]
+      },
+    },
+  ],
 };
 ```
 
 ### Batch Processing
 
 ```typescript
-async function renameBatch(renames: Array<{from: string, to: string}>) {
+async function renameBatch(renames: Array<{ from: string; to: string }>) {
   for (const { from, to } of renames) {
     const renamer = new ProjectRenamer({
       from,
       to,
       dryRun: false,
-      force: true
+      force: true,
     });
-    
+
     console.log(`Renaming ${from} to ${to}...`);
     await renamer.rename();
-    
+
     const changes = renamer.getChanges();
     console.log(`Completed: ${changes.length} changes`);
   }
@@ -431,6 +435,6 @@ const renamer = new ProjectRenamer({
   from: 'old',
   to: 'new',
   verbose: true,
-  dryRun: true
+  dryRun: true,
 });
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,6 +2,8 @@
 
 This guide is for developers working with **Java, Python, Go, Ruby, PHP, C++, or any other language** who want to use our rename tool.
 
+refacto requires Node.js 18 or newer and npm 9 or newer.
+
 ## 🤔 "I Don't Have Node.js or npm!"
 
 No problem! Here's how to get started from scratch:
@@ -11,6 +13,7 @@ No problem! Here's how to get started from scratch:
 ### Method 1: Quick Install (Recommended)
 
 #### On macOS
+
 ```bash
 # Install Homebrew if you don't have it
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -26,6 +29,7 @@ refacto --from "OldName" --to "NewName"
 ```
 
 #### On Windows
+
 ```powershell
 # Option A: Using Chocolatey
 # Install Chocolatey from https://chocolatey.org/install
@@ -44,6 +48,7 @@ npm install -g refacto
 ```
 
 #### On Linux (Ubuntu/Debian)
+
 ```bash
 # Update package list
 sudo apt update
@@ -56,6 +61,7 @@ sudo npm install -g refacto
 ```
 
 #### On Linux (Fedora/RHEL/CentOS)
+
 ```bash
 # Install Node.js and npm
 sudo dnf install nodejs npm
@@ -96,6 +102,7 @@ docker run -v $(pwd):/project rename-tool --from "OldName" --to "NewName"
 ## 🚀 Usage Examples by Language
 
 ### Java Project
+
 ```bash
 cd /path/to/my-java-project
 
@@ -111,6 +118,7 @@ refacto --from "CustomerService" --to "ClientService"
 ```
 
 ### Python Project
+
 ```bash
 cd /path/to/my-python-project
 
@@ -125,6 +133,7 @@ refacto --from "data_analyzer" --to "data_processor"
 ```
 
 ### Go Project
+
 ```bash
 cd /path/to/my-go-project
 
@@ -139,10 +148,11 @@ refacto --from "userauth" --to "authentication"
 ```
 
 ### PHP Project
+
 ```bash
 cd /path/to/my-php-project
 
-# Rename your PHP project  
+# Rename your PHP project
 refacto --from "BlogEngine" --to "ContentManager"
 
 # This will rename:
@@ -153,6 +163,7 @@ refacto --from "BlogEngine" --to "ContentManager"
 ```
 
 ### Ruby Project
+
 ```bash
 cd /path/to/my-ruby-project
 
@@ -166,6 +177,7 @@ refacto --from "payment_gateway" --to "transaction_handler"
 ```
 
 ### C/C++ Project
+
 ```bash
 cd /path/to/my-cpp-project
 
@@ -182,12 +194,14 @@ refacto --from "RenderEngine" --to "GraphicsEngine"
 ## 💡 Pro Tips
 
 ### 1. Always Use Dry Run First!
+
 ```bash
 # See what will change without making changes
 refacto --from "OldName" --to "NewName" --dry-run
 ```
 
 ### 2. Use Exact Case
+
 ```bash
 # Wrong - if your project uses "DataProcessor"
 refacto --from "dataprocessor" --to "Analytics"
@@ -197,6 +211,7 @@ refacto --from "DataProcessor" --to "Analytics"
 ```
 
 ### 3. Handle Multi-Module Projects
+
 ```bash
 # For projects with multiple modules
 cd /path/to/parent-project
@@ -204,6 +219,7 @@ refacto --from "OldModule" --to "NewModule" --verbose
 ```
 
 ### 4. Exclude Specific Directories
+
 ```bash
 # Skip vendor/third-party directories
 refacto --from "MyApp" --to "YourApp" --ignore "vendor/**" "third_party/**"
@@ -212,9 +228,11 @@ refacto --from "MyApp" --to "YourApp" --ignore "vendor/**" "third_party/**"
 ## 🆘 Troubleshooting
 
 ### "command not found: npm"
+
 You need to install Node.js first. See installation methods above.
 
 ### "command not found: refacto"
+
 ```bash
 # Make sure global npm bin is in your PATH
 export PATH="$PATH:$(npm bin -g)"
@@ -224,6 +242,7 @@ npm install -g refacto
 ```
 
 ### Permission Errors
+
 ```bash
 # On macOS/Linux, you might need sudo
 sudo npm install -g refacto
@@ -237,6 +256,7 @@ export PATH=~/.npm-global/bin:$PATH
 ### Using with Build Tools
 
 #### Maven (Java)
+
 ```xml
 <!-- Add to pom.xml -->
 <plugin>
@@ -255,6 +275,7 @@ export PATH=~/.npm-global/bin:$PATH
 ```
 
 #### Gradle (Java/Kotlin)
+
 ```groovy
 // Add to build.gradle
 task renameProject(type: Exec) {
@@ -263,6 +284,7 @@ task renameProject(type: Exec) {
 ```
 
 #### Make (C/C++)
+
 ```makefile
 # Add to Makefile
 rename:

--- a/docs/NON-JS-GUIDE.md
+++ b/docs/NON-JS-GUIDE.md
@@ -2,15 +2,20 @@
 
 ## 🚀 Install Node.js First (One Time Only)
 
+Use Node.js 18 or newer with npm 9 or newer.
+
 ### macOS
+
 ```bash
 brew install node
 ```
 
 ### Windows
+
 Download from: https://nodejs.org/en/download/
 
 ### Linux
+
 ```bash
 # Ubuntu/Debian
 sudo apt install nodejs npm
@@ -20,6 +25,7 @@ sudo dnf install nodejs npm
 ```
 
 ## 📦 Install Rename Tool
+
 ```bash
 npm install -g refacto
 ```
@@ -27,6 +33,7 @@ npm install -g refacto
 ## ✨ Use It!
 
 ### Java Example
+
 ```bash
 cd my-java-project
 refacto --from "CustomerAPI" --to "ClientAPI" --dry-run
@@ -34,6 +41,7 @@ refacto --from "CustomerAPI" --to "ClientAPI"  # Apply changes
 ```
 
 ### Python Example
+
 ```bash
 cd my-python-project
 refacto --from "data_processor" --to "data_analyzer" --dry-run
@@ -41,6 +49,7 @@ refacto --from "data_processor" --to "data_analyzer"  # Apply changes
 ```
 
 ### Any Language!
+
 ```bash
 cd my-project
 refacto --from "OldProjectName" --to "NewProjectName" --dry-run
@@ -50,6 +59,7 @@ refacto --from "OldProjectName" --to "NewProjectName"  # Apply changes
 ## 🎯 That's It!
 
 The tool will:
+
 - ✅ Rename all files and directories
 - ✅ Update all code references
 - ✅ Preserve your naming style (camelCase, snake_case, etc.)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,11 +13,13 @@ Welcome to the refacto documentation!
 ## Quick Links
 
 ### For Users
+
 - [Basic Usage](../examples/basic/) - Simple rename example
 - [Monorepo Usage](../examples/monorepo/) - Working with monorepos
 - [Programmatic API](../examples/programmatic/) - Using as a library
 
 ### For Contributors
+
 - [Project Structure](../CONTRIBUTING.md#project-structure)
 - [Development Setup](../CONTRIBUTING.md#setup)
 - [Testing Guidelines](../CONTRIBUTING.md#testing)


### PR DESCRIPTION
## Summary
Sync the release-readiness documentation updates onto `main`.

## Why
PR #34 was merged into the stacked `fix/rename-correctness-and-exports` branch after PR #33 had already landed on `main`, so the docs updates did not reach `main`.

## Changes
- Bring the README, changelog, security policy, and docs updates from the stacked docs PR onto `main`
- Update README claims for 111 tests, 98%+ source coverage, Node/npm requirements, and 8 case formats
- Document current CLI options, collision safety, dotfile coverage, and CommonJS support

## Testing
- [x] All tests pass (`npm test`)
- [x] Test coverage maintained (98%)
- [x] Tested with: `npx prettier --check README.md CHANGELOG.md SECURITY.md docs/API.md docs/INSTALLATION.md docs/NON-JS-GUIDE.md docs/README.md`; `npm test`

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if needed)
- [x] No new warnings
